### PR TITLE
20200926, fix sintel reader

### DIFF
--- a/reader/sintel.py
+++ b/reader/sintel.py
@@ -26,7 +26,7 @@ def list_data(path = None):
 				c = 0
 				dataset[part + str(1)][subset] = []
 				dataset[part + str(2)][subset] = []
-			for seq in os.listdir(os.path.join(path, part, subset)):
+			for seq in sorted(os.listdir(os.path.join(path, part, subset))):
 				frames = os.listdir(os.path.join(path, part, subset, seq))
 				frames = list(sorted(map(lambda s: int(pattern.match(s).group(1)),
 									 filter(lambda s: pattern.match(s), frames))))


### PR DESCRIPTION
'os.listdir' will return different results in different filesystems, add 'sorted()' to make sure the order.

Refer to this issue: https://stackoverflow.com/questions/4813061/non-alphanumeric-list-order-from-os-listdir